### PR TITLE
Added possibility to filter out categories in plot

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(main main.cpp
         ui/charts/BarGraph.h
         ui/charts/GraphArea.cpp
         ui/charts/GraphArea.h
-        )
+        ui/plotting/PlotCategoryFilter.cpp ui/plotting/PlotCategoryFilter.h)
 target_link_libraries(main ${Qt5Widgets_LIBRARIES})
 target_link_libraries(main ${Qt5Sql_LIBRARIES})
 

--- a/src/data/ResourceHandler.cpp
+++ b/src/data/ResourceHandler.cpp
@@ -27,7 +27,7 @@ ResourceHandler::initColors()
     for (size_t count = 0; count < RANGE; ++count)
     {
         char buf[10];
-        std::sprintf(buf, "color%02lu", ((count*5)%RANGE)+1);
+        std::sprintf(buf, "color%02lu", count+1);
         constexpr int value = static_cast<int>(0.8 * 256);
         constexpr int saturation = static_cast<int>(0.7 * 256);
         const int hue = static_cast<int>(count/ static_cast<double>(RANGE) * 360);

--- a/src/data/ResourceHandler.h
+++ b/src/data/ResourceHandler.h
@@ -32,7 +32,7 @@ public:
     /**
      * Number of numbered colors, e.g. color04.light/dark
      */
-    static constexpr size_t numberedColorRange {16};
+    static constexpr size_t numberedColorRange {20};
 protected:
     void initColors();
 

--- a/src/ui/charts/GraphArea.cpp
+++ b/src/ui/charts/GraphArea.cpp
@@ -42,7 +42,14 @@ GraphArea::paintEvent(QPaintEvent * evt)
         painter.setPen(black);
         QFont f ("Monospace", 8);
         painter.setFont(f);
-        painter.drawText(it.second.boundingRect().x() -5, it.second.boundingRect().bottom() + 15, it.first);
+        painter.rotate(-90);
+        painter.drawText(
+                //it.second.boundingRect().x() -5,
+                //it.second.boundingRect().bottom() + 15,
+                -it.second.boundingRect().bottom() - 80,
+                it.second.boundingRect().x() + 27,
+                it.first);
+        painter.rotate(90);
     }
 }
 
@@ -60,7 +67,7 @@ GraphArea::rebuildBars()
     int const numBars = int(bars.size());
     int widthPerBar = (width() - xOffsetGlobal)/numBars;
     if (widthPerBar > 120) widthPerBar = 120;
-    heightPerBar = height() - 60;
+    heightPerBar = height() - 100;
     int const xOffset = 20;
     yOffset = 20;
 

--- a/src/ui/plotting/PlotArea.cpp
+++ b/src/ui/plotting/PlotArea.cpp
@@ -13,9 +13,10 @@ int const PlotArea::zoomLevels [] = { 5, 8, 12, 20, 32, 50, 64, 80, 100 };
 
 PlotArea::PlotArea(QWidget * parent)
 : QWidget(parent),
-  zoomLevel(5)
+  zoomLevel(3)
 {
     setMouseTracking(true);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 }
 
 void
@@ -78,18 +79,31 @@ PlotArea::paintEvent(QPaintEvent * evt) {
     p.setDrawMinMax(paintMinMax);
     p.addPoints(cumulativeSums);
     p.plot(&painter);
+}
 
-
-    // test: plot colors
-    for (int i = 1; i < 17; ++i) {
-        char buf[40];
-        std::sprintf(buf, "color%02d.light", i);
-        painter.setBrush(ResourceHandler::getInstance()->getColor(QString(buf)));
-        painter.drawRect(20 * i, 20, 20, 20);
-        std::sprintf(buf, "color%02d.dark", i);
-        painter.setBrush(ResourceHandler::getInstance()->getColor(QString(buf)));
-        painter.drawRect(20 * i, 40, 20, 20);
+QString
+PlotArea::buildQuery() const
+{
+    QString query;
+    query += "SELECT Item.date as date, Item.price as price ";
+    query += "FROM Item ";
+    if (filters.size() > 0)
+    {
+        query += "JOIN Category On Category.id = Item.catid ";
+        query += "WHERE Category.name IN (";
+        for (size_t i = 0; i < filters.size()-1; ++i)
+        {
+            query += "'";
+            query += filters[i];
+            query += "', ";
+        }
+        query += "'";
+        query += filters.back();
+        query += "') ";
     }
+    query += "ORDER BY date ASC;";
+
+    return query;
 }
 
 void
@@ -101,7 +115,7 @@ PlotArea::reloadData()
     std::map<QDate, std::tuple<double, double, double>> accumPerDay;
 
     QSqlQuery query (DbHandler::getInstance()->getDatabase());
-    query.exec("SELECT date, price FROM Item ORDER BY date ASC;");
+    query.exec(buildQuery()); //"SELECT date, price FROM Item ORDER BY date ASC;");
     while (query.next())
     {
         QDate d = query.value("date").toDate();

--- a/src/ui/plotting/PlotArea.h
+++ b/src/ui/plotting/PlotArea.h
@@ -34,6 +34,11 @@ public slots:
     inline bool const& isPaintMinMax() { return paintMinMax; };
     inline void setPaintMinMax(bool const& b) { paintMinMax = b; emit repaint(); };
 
+    void setFilters(std::vector<QString> filters)
+    {
+        this->filters = filters;
+    }
+
 signals:
     void canDecrementZoomLevel(bool);
     void canIncrementZoomLevel(bool);
@@ -49,11 +54,14 @@ private:
     const int marginLeft = 60;
 
     inline int const& dayWidth() const { return zoomLevels[zoomLevel]; }
+    QString buildQuery() const;
     int zoomLevel;
     static constexpr int maxZoomLevel = 8;
     static const int zoomLevels [maxZoomLevel+1];
 
     bool paintMinMax = true;
+
+    std::vector<QString> filters;
 };
 
 

--- a/src/ui/plotting/PlotCategoryFilter.cpp
+++ b/src/ui/plotting/PlotCategoryFilter.cpp
@@ -1,0 +1,76 @@
+//
+// Created by max on 16/11/16.
+//
+
+#include <QtWidgets/QPushButton>
+#include <QtCore/QVariant>
+#include "PlotCategoryFilter.h"
+
+PlotCategoryFilter::PlotCategoryFilter(QWidget * parent)
+: QWidget(parent)
+{
+    mainArea = new QScrollArea;
+    mainLayout = new QVBoxLayout;
+    scrollAreaLayout = new QVBoxLayout;
+
+    mainLayout->setSpacing(0);
+    mainLayout->setContentsMargins(0,0,0,0);
+    scrollAreaLayout->setSpacing(0);
+    scrollAreaLayout->setContentsMargins(0,0,0,0);
+    scrollAreaLayout->setAlignment(Qt::AlignTop);
+
+    setLayout(mainLayout);
+    mainLayout->addWidget(mainArea);
+    mainArea->setLayout(scrollAreaLayout);
+
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+    setMaximumWidth(100);
+}
+
+void
+PlotCategoryFilter::clearFilters()
+{
+    for (auto const& widget : widgets)
+    {
+        mainArea->layout()->removeWidget(widget);
+    }
+
+    widgets.clear();
+}
+
+void
+PlotCategoryFilter::addFilter(QString const& name, QColor const& color)
+{
+    QPushButton * button = new QPushButton(name);
+    button->setCheckable(true);
+
+    char buf [256];
+    std::sprintf(buf, "QPushButton { background-color: rgb(180,180,180); }\nQPushButton:checked { background-color: rgb(%d,%d,%d); }",
+        color.red(), color.green(), color.blue()
+    );
+    button->setStyleSheet(QString(buf));
+    //QPalette pal = button->palette();
+    //pal.setColor(QPalette::Button, color);
+    //button->setAutoFillBackground(true);
+    //button->setPalette(pal);
+    //button->update();
+    button->setChecked(true);
+
+    widgets.push_back(button);
+    mainArea->layout()->addWidget(button);
+}
+
+std::vector<QString>
+PlotCategoryFilter::getSelected() const
+{
+    std::vector<QString> vec;
+    for (QPushButton* const& w : widgets)
+    {
+        if (w->isChecked())
+        {
+            vec.push_back(w->text());
+        }
+    }
+
+    return vec;
+}

--- a/src/ui/plotting/PlotCategoryFilter.h
+++ b/src/ui/plotting/PlotCategoryFilter.h
@@ -1,0 +1,32 @@
+//
+// Created by max on 16/11/16.
+//
+
+#pragma once
+
+#include <QtWidgets/QWidget>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QScrollArea>
+
+class PlotCategoryFilter : public QWidget {
+public:
+    PlotCategoryFilter() = delete;
+    PlotCategoryFilter(PlotCategoryFilter const&) = delete;
+    PlotCategoryFilter& operator= (PlotCategoryFilter const&) = delete;
+    PlotCategoryFilter(QWidget * parent);
+    ~PlotCategoryFilter() = default;
+
+    void clearFilters();
+    void addFilter(QString const& name, QColor const& color);
+
+    std::vector<QString> getSelected() const;
+
+private:
+    QVBoxLayout * mainLayout;
+    QScrollArea * mainArea;
+    QVBoxLayout * scrollAreaLayout;
+
+    std::vector<QPushButton *> widgets;
+};
+
+

--- a/src/ui/tabs/PlotTab.h
+++ b/src/ui/tabs/PlotTab.h
@@ -12,6 +12,7 @@
 #include <QtWidgets/QScrollArea>
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QPushButton>
+#include <ui/plotting/PlotCategoryFilter.h>
 #include "ui/plotting/PlotArea.h"
 
 class PlotTab : public QWidget
@@ -25,6 +26,8 @@ protected slots:
     void onDataChanged();
 
 private:
+    void rebuildCategories();
+
     QScrollArea * plotAreaWrapper;
     PlotArea * plotArea;
 
@@ -33,7 +36,10 @@ private:
     QPushButton * zoomOutButton;
     QPushButton * enableMinMaxDrawingButton;
 
+    PlotCategoryFilter * sideButtons;
+
     QVBoxLayout * mainLayout;
+    QHBoxLayout * allLayout;
     QHBoxLayout * bottomButtonLayout;
 };
 


### PR DESCRIPTION
Added bar at right with checkable categories. Only checked categories
are incorporated in the plot. The only requeries after clicking repaint
button.

Rotated text in bar chart to stop overlaps.